### PR TITLE
Update origin-cli Dockerfile to include git

### DIFF
--- a/images/cli/Dockerfile
+++ b/images/cli/Dockerfile
@@ -6,7 +6,7 @@
 #
 FROM openshift/origin-base
 
-RUN INSTALL_PKGS="origin-clients" && \
+RUN INSTALL_PKGS="origin-clients git" && \
     yum --enablerepo=origin-local-release install -y ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     yum clean all


### PR DESCRIPTION
Git is need to create applications and builds bases on git repositories.

This makes possible to use this image as base for ci-cd environments targeting openshift.